### PR TITLE
MDL-79112 lib/db: Fix broken install.xml caused by rebase

### DIFF
--- a/lib/db/install.xml
+++ b/lib/db/install.xml
@@ -4970,5 +4970,20 @@
         <KEY NAME="categoryid" TYPE="foreign" FIELDS="categoryid" REFTABLE="course_categories" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
+    <TABLE NAME="lti_coursevisible" COMMENT="Table to store coursevisible setting for site tool on course level">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="typeid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Course ID"/>
+        <FIELD NAME="coursevisible" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="courseid" UNIQUE="false" FIELDS="courseid"/>
+        <INDEX NAME="typeid" UNIQUE="false" FIELDS="typeid"/>
+      </INDEXES>
+    </TABLE>
   </TABLES>
 </XMLDB>

--- a/lib/db/install.xml
+++ b/lib/db/install.xml
@@ -4917,6 +4917,14 @@
         <FIELD NAME="originalgrade" TYPE="number" LENGTH="10" NOTNULL="true" SEQUENCE="false" DECIMALS="5"/>
         <FIELD NAME="launchid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="state" TYPE="int" LENGTH="2" NOTNULL="true" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="ltiid" UNIQUE="false" FIELDS="ltiid"/>
+      </INDEXES>
+    </TABLE>
     <TABLE NAME="moodlenet_share_progress" COMMENT="Records MoodleNet share progress">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
@@ -4931,9 +4939,6 @@
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
-      <INDEXES>
-        <INDEX NAME="ltiid" UNIQUE="false" FIELDS="ltiid"/>
-      </INDEXES>
     </TABLE>
     <TABLE NAME="lti_access_tokens" COMMENT="Security tokens for accessing of LTI services">
       <FIELDS>


### PR DESCRIPTION
Looks like this was broken in a rebase somewhere along the way, without this change the file is broken and you can't install